### PR TITLE
Update bp-security-check.php

### DIFF
--- a/bp-security-check.php
+++ b/bp-security-check.php
@@ -87,6 +87,8 @@ class BuddyPress_Security_Check {
 			$a = $b;      // assign $a (lower number) to $b (higher number)
 			$b = $_a;     // assign $b to the original $a
 			unset( $_a ); // destroy the backup variable
+		} elseif ($a == $b) {
+			$a++;  // Increment $a so that we never get 0 and hit validation errors being required
 		}
 
 		/* Get a random operation */


### PR DESCRIPTION
Quick fix for issue involving when $a == $b and being required.  Required fields can't be 0 or empty so it will error out even though the user answered it correctly.
